### PR TITLE
Introduce typed response models for Asana wrapper

### DIFF
--- a/src/cli/cli.py
+++ b/src/cli/cli.py
@@ -6,6 +6,7 @@ from src.core.config import get_settings
 from src.core.wrapper import create_project_from_json, create_tasks_in_project
 from src.core.asana_mapping_generator import generate_asana_mapping
 from src.core.openapi_exporter import export_openapi_yaml
+from src.core.models import ProjectSpec, TaskSpec
 
 app = typer.Typer(add_completion=False, help="Provision Asana objects from JSON")
 
@@ -17,14 +18,15 @@ def _load_json(path: Path):
 
 @app.command("create-project")
 def create_project(file: Path = typer.Option(..., exists=True, readable=True, help="Path to project spec JSON")):
-    spec = _load_json(file)
+    raw_spec = _load_json(file)
+    spec = ProjectSpec.model_validate(raw_spec)
     result = create_project_from_json(spec)
-    proj = result["project"]
-    typer.echo(f"Created project: {proj['name']} (gid={proj['gid']})")
-    if result.get("sections"):
-        typer.echo(f"  Sections: {[s['name'] for s in result['sections']]}")
-    if result.get("tasks"):
-        typer.echo(f"  Tasks created: {len(result['tasks'])}")
+    proj = result.project
+    typer.echo(f"Created project: {proj.name} (gid={proj.gid})")
+    if result.sections:
+        typer.echo(f"  Sections: {[s.name for s in result.sections]}")
+    if result.tasks:
+        typer.echo(f"  Tasks created: {len(result.tasks)}")
 
 
 @app.command("add-tasks")
@@ -32,7 +34,8 @@ def add_tasks(
         project: str = typer.Option(..., "--project", "-p", help="Target project GID"),
         file: Path = typer.Option(..., exists=True, readable=True, help="Path to tasks JSON list"),
 ):
-    tasks_spec = _load_json(file)
+    raw_tasks = _load_json(file)
+    tasks_spec = [TaskSpec.model_validate(t) for t in raw_tasks]
     created = create_tasks_in_project(project_gid=project, tasks_spec=tasks_spec)
     typer.echo(f"Created {len(created)} tasks in project {project}")
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class SectionSpec(BaseModel):
@@ -44,4 +44,36 @@ def project_spec_schema() -> dict[str, Any]:
 
 # Resolve forward references for TaskSpec
 TaskSpec.model_rebuild()
+
+
+class AsanaObject(BaseModel):
+    gid: str
+    name: str | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class SectionResult(AsanaObject):
+    pass
+
+
+class TaskResult(AsanaObject):
+    pass
+
+
+class ProjectRecord(AsanaObject):
+    notes: str | None = None
+
+
+class ProjectResult(BaseModel):
+    project: ProjectRecord
+    sections: list[SectionResult] = []
+    tasks: list[TaskResult] = []
+
+
+class MappingResult(BaseModel):
+    projects: dict[str, str]
+    sections: dict[str, dict[str, str]]
+    custom_fields: dict[str, dict[str, Any]]
+    tags: dict[str, str]
+    users: dict[str, str]
 

--- a/src/core/wrapper.py
+++ b/src/core/wrapper.py
@@ -3,7 +3,15 @@ from typing import Any
 
 from .asana_client import get_client, with_backoff
 from .config import get_settings
-from .models import ProjectMeta, ProjectSpec, TaskSpec
+from .models import (
+    ProjectMeta,
+    ProjectRecord,
+    ProjectResult,
+    ProjectSpec,
+    SectionResult,
+    TaskResult,
+    TaskSpec,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -96,11 +104,8 @@ def _create_subtasks_recursive(client, parent_task_gid: str, project_gid: str, s
             _create_subtasks_recursive(client, created["gid"], project_gid, st.subtasks)
 
 
-def create_project_from_json(spec: ProjectSpec) -> dict[str, Any]:
-    """Create a project (and optional sections + tasks) from a JSON-like dict.
-
-    Returns a dictionary with keys: project, sections (list), tasks (list).
-    """
+def create_project_from_json(spec: ProjectSpec) -> ProjectResult:
+    """Create a project and return structured metadata."""
     client = get_client()
     settings = get_settings()
 
@@ -117,20 +122,22 @@ def create_project_from_json(spec: ProjectSpec) -> dict[str, Any]:
 
     project = with_backoff(client.projects.create, p_payload)
 
-    created_sections: list[dict] = []
+    created_sections: list[SectionResult] = []
     section_name_to_gid: dict[str, str] = {}
 
     # Create sections if provided
     for s in spec.sections or []:
         sec = _create_section(client, project["gid"], s.name or "Section")
         if sec:
-            created_sections.append(sec)
-            section_name_to_gid[sec["name"]] = sec["gid"]
+            sec_model = SectionResult.model_validate(sec)
+            created_sections.append(sec_model)
+            if sec_model.name:
+                section_name_to_gid[sec_model.name] = sec_model.gid
 
     # Also map any preexisting sections (covers cases where project template has them)
     section_name_to_gid.update(_map_section_names(client, project["gid"]))
 
-    created_tasks: list[dict] = []
+    created_tasks: list[TaskResult] = []
     # Create tasks
     for t in spec.tasks or []:
         if not t.name:
@@ -138,29 +145,32 @@ def create_project_from_json(spec: ProjectSpec) -> dict[str, Any]:
             continue
         payload = _build_task_payload(project["gid"], t, section_name_to_gid)
         created = with_backoff(client.tasks.create, payload)
-        created_tasks.append(created)
+        task_model = TaskResult.model_validate(created)
+        created_tasks.append(task_model)
         # Subtasks
         if t.subtasks:
-            _create_subtasks_recursive(client, created["gid"], project["gid"], t.subtasks)
+            _create_subtasks_recursive(client, task_model.gid, project["gid"], t.subtasks)
 
-    return {"project": project, "sections": created_sections, "tasks": created_tasks}
+    project_model = ProjectRecord.model_validate(project)
+    return ProjectResult(project=project_model, sections=created_sections, tasks=created_tasks)
 
 
-def create_tasks_in_project(project_gid: str, tasks_spec: list[TaskSpec]) -> list[dict]:
+def create_tasks_in_project(project_gid: str, tasks_spec: list[TaskSpec]) -> list[TaskResult]:
     """Add tasks to an existing project from a list of TaskSpec models."""
     client = get_client()
     # Map section names if caller uses section_name
     section_name_to_gid = _map_section_names(client, project_gid)
 
-    created: list[dict] = []
+    created: list[TaskResult] = []
     for t in tasks_spec:
         if not t.name:
             logger.warning("Skipping task with no name: %s", t)
             continue
         payload = _build_task_payload(project_gid, t, section_name_to_gid)
         task = with_backoff(client.tasks.create, payload)
-        created.append(task)
+        task_model = TaskResult.model_validate(task)
+        created.append(task_model)
         if t.subtasks:
-            _create_subtasks_recursive(client, task["gid"], project_gid, t.subtasks)
+            _create_subtasks_recursive(client, task_model.gid, project_gid, t.subtasks)
     return created
 

--- a/src/web/endpoints.py
+++ b/src/web/endpoints.py
@@ -1,37 +1,24 @@
 """FastAPI endpoints exposing Asana helper utilities for LLM use."""
 
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Body
-from pydantic import BaseModel
 
 from src.core.wrapper import create_project_from_json, create_tasks_in_project
 from src.core.asana_mapping_generator import generate_asana_mapping
-from src.core.models import ProjectSpec, TaskSpec
+from src.core.models import (
+    MappingResult,
+    ProjectResult,
+    ProjectSpec,
+    TaskResult,
+    TaskSpec,
+)
 
 router = APIRouter()
 
 
-class ProjectCreationResult(BaseModel):
-    project: dict[str, Any]
-    sections: list[dict[str, Any]]
-    tasks: list[dict[str, Any]]
-
-
-class TasksCreationResult(BaseModel):
-    tasks: list[dict[str, Any]]
-
-
-class MappingModel(BaseModel):
-    projects: dict[str, str]
-    sections: dict[str, dict[str, str]]
-    custom_fields: dict[str, dict[str, Any]]
-    tags: dict[str, str]
-    users: dict[str, str]
-
-
 @router.post("/project")
-def create_project(spec: ProjectSpec = Body(...)) -> ProjectCreationResult:
+def create_project(spec: ProjectSpec = Body(...)) -> ProjectResult:
     """Create an Asana project from a JSON specification.
 
     Parameters
@@ -51,19 +38,19 @@ def create_project(spec: ProjectSpec = Body(...)) -> ProjectCreationResult:
 
     Returns
     -------
-    ProjectCreationResult
+    ProjectResult
         ``{"project": {...}, "sections": [...], "tasks": [...]}``
     """
 
     result = create_project_from_json(spec)
-    return ProjectCreationResult(**result)
+    return result
 
 
 @router.post("/project/{project_gid}/tasks")
 def create_tasks(
     project_gid: str,
     tasks: list[TaskSpec] = Body(...),
-) -> TasksCreationResult:
+) -> list[TaskResult]:
     """Add tasks to an existing project.
 
     Parameters
@@ -85,19 +72,19 @@ def create_tasks(
 
     Returns
     -------
-    TasksCreationResult
-        Wrapper around the list of task objects returned by the Asana API.
+    list[TaskResult]
+        List of task objects returned by the Asana API.
     """
 
     created = create_tasks_in_project(project_gid, tasks)
-    return TasksCreationResult(tasks=created)
+    return created
 
 
 @router.post("/mapping")
 def generate_mapping(
     workspace_gid: Optional[str] = None,
     projects: Optional[list[str]] = None,
-) -> MappingModel:
+) -> MappingResult:
     """Generate a lightweight mapping of Asana identifiers.
 
     Parameters
@@ -110,7 +97,7 @@ def generate_mapping(
 
     Returns
     -------
-    MappingModel
+    MappingResult
         Mapping with schema::
 
             {
@@ -131,4 +118,4 @@ def generate_mapping(
         workspace_gid=workspace_gid,
         projects=projects,
     )
-    return MappingModel(**mapping)
+    return MappingResult(**mapping)


### PR DESCRIPTION
## Summary
- Define Pydantic models for Asana API responses
- Return structured models from core wrapper functions
- Update FastAPI endpoints and CLI to use typed results

## Testing
- `python -m py_compile src/core/models.py src/core/wrapper.py src/web/endpoints.py src/cli/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68acbdb1740083219861c50f5ad639b0