### PR TITLE
feat: create custom fields during project provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provision **Asana projects** and **tasks** from plain JSON. Keep credentials and
     - **Sections** (by GID, or best-effort by name)
     - **Subtasks** (recursive)
     - **Notes**, **due dates**, **assignees**
-    - **Followers**, **tags**, **custom fields**
+    - **Followers**, **tags**, **custom fields** (define fields and reference them by name)
 - CLI (`provision`) and Python API
 - Simple exponential backoff for Asana **rate limits**
 
@@ -69,7 +69,7 @@ poetry run provision create-project --file examples/project_with_tasks.json
 poetry run provision add-tasks --project 120987654321 --file examples/tasks_only.json
 ```
 
-> Prefer **GIDs** for users, sections, tags, and custom fields. Name-based lookups vary by org and SDK version and are best used as a fallback.
+> Prefer **GIDs** for users, sections, and tags. Custom fields defined in the same JSON may be referenced by name; otherwise use GIDs.
 
 ---
 

--- a/examples/project_with_tasks.json
+++ b/examples/project_with_tasks.json
@@ -4,6 +4,39 @@
     "notes": "Q4 launch plan",
     "privacy": "private"
   },
+  "custom_fields": [
+    {
+      "name": "Urgency",
+      "resource_subtype": "enum",
+      "options": [
+        { "name": "Urgent", "color": "red" },
+        { "name": "Soon", "color": "yellow" },
+        { "name": "Eventually", "color": "blue" }
+      ]
+    },
+    {
+      "name": "Effort",
+      "resource_subtype": "number"
+    },
+    {
+      "name": "Workstream",
+      "resource_subtype": "enum",
+      "options": [
+        { "name": "Engineering", "color": "blue" },
+        { "name": "Design", "color": "purple" },
+        { "name": "Marketing", "color": "green" }
+      ]
+    },
+    {
+      "name": "Importance",
+      "resource_subtype": "enum",
+      "options": [
+        { "name": "High", "color": "red" },
+        { "name": "Medium", "color": "yellow" },
+        { "name": "Low", "color": "green" }
+      ]
+    }
+  ],
   "sections": [
     { "name": "Backlog" },
     { "name": "In Progress" },
@@ -17,7 +50,12 @@
       "due_on": "2025-09-01",
       "followers": ["1200123", "1200456"],
       "tags": ["1200789"],
-      "custom_fields": { "123456": "High" },
+      "custom_fields": {
+        "Urgency": "Urgent",
+        "Effort": 5,
+        "Workstream": "Engineering",
+        "Importance": "High"
+      },
       "section_name": "Backlog",
       "subtasks": [
         { "name": "Book room" },
@@ -27,6 +65,12 @@
     {
       "name": "Design Assets",
       "notes": "Hero image + variants",
+      "custom_fields": {
+        "Urgency": "Soon",
+        "Effort": 3,
+        "Workstream": "Design",
+        "Importance": "Low"
+      },
       "section_name": "In Progress"
     }
   ]

--- a/src/core/asana_client.py
+++ b/src/core/asana_client.py
@@ -122,9 +122,20 @@ def get_client() -> any:
             path = f"/projects/{project_gid}/custom_field_settings"
             return self._http.request_paginated("GET", path, params=params)
 
+        def add_to_project(self, project_gid: str, custom_field_gid: str) -> dict:
+            # POST /projects/{project_gid}/addCustomFieldSetting
+            body = _wrap_data({"custom_field": custom_field_gid})
+            path = f"/projects/{project_gid}/addCustomFieldSetting"
+            return with_backoff(self._http.request, "POST", path, json=body)
+
     class CustomFieldsProxy:
         def __init__(self, http_client: HttpClient) -> None:
             self._http = http_client
+
+        def create(self, payload: dict) -> dict:
+            # POST /custom_fields
+            body = _wrap_data(payload)
+            return with_backoff(self._http.request, "POST", "/custom_fields", json=body)
 
         def get(self, custom_field_gid: str, *, opt_fields: Optional[str] = None) -> dict:
             # GET /custom_fields/{gid}

--- a/src/core/asana_mapping_generator.py
+++ b/src/core/asana_mapping_generator.py
@@ -45,10 +45,10 @@ def _collect_custom_fields_for_project(client, project_gid: str) -> dict[str, An
     """
     Returns:
     {
-      "Priority": {
+      "Importance": {
         "field_gid": "...",
         "resource_subtype": "enum",
-        "options": {"High": "...", "Medium": "..."}
+        "options": {"High": "...", "Medium": "...", "Low": "..."}
       },
       ...
     }

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -28,9 +28,22 @@ class ProjectMeta(BaseModel):
     privacy: str | None = None  # "private" | "public_to_team" etc.
 
 
+class EnumOptionSpec(BaseModel):
+    name: str
+    color: str | None = None
+
+
+class CustomFieldSpec(BaseModel):
+    name: str
+    resource_subtype: str
+    description: str | None = None
+    options: list[EnumOptionSpec] | None = None
+
+
 class ProjectSpec(BaseModel):
     project: ProjectMeta | None = None
     sections: list[SectionSpec] | None = None
+    custom_fields: list[CustomFieldSpec] | None = None
     tasks: list[TaskSpec] | None = None
 
 

--- a/src/core/wrapper.py
+++ b/src/core/wrapper.py
@@ -51,7 +51,53 @@ def _map_section_names(client, project_gid: str) -> dict[str, str]:
     return mapping
 
 
-def _build_task_payload(project_gid: str, t: TaskSpec, section_name_to_gid: dict[str, str]) -> dict[str, Any]:
+def _map_custom_fields(client, project_gid: str) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
+    name_to_gid: dict[str, str] = {}
+    option_map: dict[str, dict[str, str]] = {}
+    field_settings = client.custom_field_settings.list_for_project(
+        project_gid, opt_fields="custom_field.name,custom_field.enum_options"
+    )
+    for setting in field_settings:
+        field = setting.get("custom_field") or {}
+        name = field.get("name")
+        gid = field.get("gid")
+        if name and gid:
+            name_to_gid[name] = gid
+            options_map: dict[str, str] = {}
+            for option in field.get("enum_options") or []:
+                option_name = option.get("name")
+                option_gid = option.get("gid")
+                if option_name and option_gid:
+                    options_map[option_name] = option_gid
+            if options_map:
+                option_map[name] = options_map
+                option_map[gid] = options_map
+    return name_to_gid, option_map
+
+
+def _translate_custom_fields(
+    custom_fields: dict[str, Any],
+    name_to_gid: dict[str, str],
+    option_map: dict[str, dict[str, str]],
+) -> dict[str, Any]:
+    translated: dict[str, Any] = {}
+    for key, value in custom_fields.items():
+        field_gid = name_to_gid.get(key, key)
+        if isinstance(value, str):
+            options = option_map.get(key) or option_map.get(field_gid) or {}
+            translated[field_gid] = options.get(value, value)
+        else:
+            translated[field_gid] = value
+    return translated
+
+
+def _build_task_payload(
+    project_gid: str,
+    t: TaskSpec,
+    section_name_to_gid: dict[str, str],
+    custom_field_name_to_gid: dict[str, str],
+    custom_field_option_map: dict[str, dict[str, str]],
+) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "name": t.name,
         "projects": [project_gid],
@@ -67,7 +113,11 @@ def _build_task_payload(project_gid: str, t: TaskSpec, section_name_to_gid: dict
     if t.tags is not None:
         payload["tags"] = t.tags
     if t.custom_fields is not None:
-        payload["custom_fields"] = t.custom_fields
+        payload["custom_fields"] = _translate_custom_fields(
+            t.custom_fields,
+            custom_field_name_to_gid,
+            custom_field_option_map,
+        )
 
     # Section placement (prefer explicit GID; else name lookup)
     memberships = []
@@ -82,7 +132,14 @@ def _build_task_payload(project_gid: str, t: TaskSpec, section_name_to_gid: dict
     return payload
 
 
-def _create_subtasks_recursive(client, parent_task_gid: str, project_gid: str, subtasks: list[TaskSpec]) -> None:
+def _create_subtasks_recursive(
+    client,
+    parent_task_gid: str,
+    project_gid: str,
+    subtasks: list[TaskSpec],
+    custom_field_name_to_gid: dict[str, str],
+    custom_field_option_map: dict[str, dict[str, str]],
+) -> None:
     for st in subtasks:
         sub_payload = {"name": st.name, "parent": parent_task_gid}
         # Optional attributes for subtasks
@@ -95,13 +152,24 @@ def _create_subtasks_recursive(client, parent_task_gid: str, project_gid: str, s
         if st.tags is not None:
             sub_payload["tags"] = st.tags
         if st.custom_fields is not None:
-            sub_payload["custom_fields"] = st.custom_fields
+            sub_payload["custom_fields"] = _translate_custom_fields(
+                st.custom_fields,
+                custom_field_name_to_gid,
+                custom_field_option_map,
+            )
         # Optional: include project membership for visibility
         if st.inherit_project_membership:
             sub_payload["projects"] = [project_gid]
         created = with_backoff(client.tasks.create, sub_payload)
         if st.subtasks:
-            _create_subtasks_recursive(client, created["gid"], project_gid, st.subtasks)
+            _create_subtasks_recursive(
+                client,
+                created["gid"],
+                project_gid,
+                st.subtasks,
+                custom_field_name_to_gid,
+                custom_field_option_map,
+            )
 
 
 def create_project_from_json(spec: ProjectSpec) -> ProjectResult:
@@ -137,19 +205,55 @@ def create_project_from_json(spec: ProjectSpec) -> ProjectResult:
     # Also map any preexisting sections (covers cases where project template has them)
     section_name_to_gid.update(_map_section_names(client, project["gid"]))
 
+    # Create custom fields and attach to project
+    for field_spec in spec.custom_fields or []:
+        field_payload: dict[str, Any] = {
+            "name": field_spec.name,
+            "resource_subtype": field_spec.resource_subtype,
+            "workspace": settings.workspace_gid,
+        }
+        if field_spec.description:
+            field_payload["description"] = field_spec.description
+        if field_spec.options:
+            field_payload["enum_options"] = [
+                {"name": option.name, **({"color": option.color} if option.color else {})}
+                for option in field_spec.options
+            ]
+        created_field = with_backoff(client.custom_fields.create, field_payload)
+        with_backoff(
+            client.custom_field_settings.add_to_project,
+            project["gid"],
+            created_field["gid"],
+        )
+
+    custom_field_name_to_gid, custom_field_option_map = _map_custom_fields(client, project["gid"])
+
     created_tasks: list[TaskResult] = []
     # Create tasks
     for t in spec.tasks or []:
         if not t.name:
             logger.warning("Skipping task with no name: %s", t)
             continue
-        payload = _build_task_payload(project["gid"], t, section_name_to_gid)
+        payload = _build_task_payload(
+            project["gid"],
+            t,
+            section_name_to_gid,
+            custom_field_name_to_gid,
+            custom_field_option_map,
+        )
         created = with_backoff(client.tasks.create, payload)
         task_model = TaskResult.model_validate(created)
         created_tasks.append(task_model)
         # Subtasks
         if t.subtasks:
-            _create_subtasks_recursive(client, task_model.gid, project["gid"], t.subtasks)
+            _create_subtasks_recursive(
+                client,
+                task_model.gid,
+                project["gid"],
+                t.subtasks,
+                custom_field_name_to_gid,
+                custom_field_option_map,
+            )
 
     project_model = ProjectRecord.model_validate(project)
     return ProjectResult(project=project_model, sections=created_sections, tasks=created_tasks)
@@ -160,17 +264,31 @@ def create_tasks_in_project(project_gid: str, tasks_spec: list[TaskSpec]) -> lis
     client = get_client()
     # Map section names if caller uses section_name
     section_name_to_gid = _map_section_names(client, project_gid)
+    custom_field_name_to_gid, custom_field_option_map = _map_custom_fields(client, project_gid)
 
     created: list[TaskResult] = []
     for t in tasks_spec:
         if not t.name:
             logger.warning("Skipping task with no name: %s", t)
             continue
-        payload = _build_task_payload(project_gid, t, section_name_to_gid)
+        payload = _build_task_payload(
+            project_gid,
+            t,
+            section_name_to_gid,
+            custom_field_name_to_gid,
+            custom_field_option_map,
+        )
         task = with_backoff(client.tasks.create, payload)
         task_model = TaskResult.model_validate(task)
         created.append(task_model)
         if t.subtasks:
-            _create_subtasks_recursive(client, task_model.gid, project_gid, t.subtasks)
+            _create_subtasks_recursive(
+                client,
+                task_model.gid,
+                project_gid,
+                t.subtasks,
+                custom_field_name_to_gid,
+                custom_field_option_map,
+            )
     return created
 


### PR DESCRIPTION
## Summary
- remove mistaken support for project-level `is_important`
- expand example to create Urgency, Effort, Workstream, and Importance fields and reference them by name
- update mapping generator docs to illustrate Importance field usage

## Testing
- `poetry install --no-root` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run provision --help` *(fails: Command not found: provision)*
- `python -m py_compile src/core/asana_client.py src/core/models.py src/core/wrapper.py src/core/asana_mapping_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68ace9d575688321bd9a271599b0d77a