### PR TITLE
feat: support tag creation and task tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Provision **Asana projects** and **tasks** from plain JSON. Keep credentials and
     - **Subtasks** (recursive)
     - **Notes**, **due dates**, **assignees**
     - **Followers**, **tags**, **custom fields** (define fields and reference them by name)
+- Create **tags** and attach them to tasks
 - CLI (`provision`) and Python API
 - Simple exponential backoff for Asana **rate limits**
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -128,6 +128,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /tag:
+    post:
+      summary: Create Tag
+      description: Create a tag in the configured workspace.
+      operationId: create_tag_tag_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TagSpec'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagResult'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /task/{task_gid}/tags:
+    post:
+      summary: Add Tags
+      description: Attach existing tags to a task.
+      operationId: add_tags_task__task_gid__tags_post
+      parameters:
+      - name: task_gid
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Task Gid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+              title: Tag Gids
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TagResult'
+                title: Response Add Tags Task  Task Gid  Tags Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
     HTTPValidationError:
@@ -282,6 +343,40 @@ components:
           title: Name
       type: object
       title: SectionSpec
+    TagResult:
+      properties:
+        gid:
+          type: string
+          title: Gid
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Name
+      additionalProperties: true
+      type: object
+      required:
+      - gid
+      title: TagResult
+    TagSpec:
+      properties:
+        name:
+          type: string
+          title: Name
+        color:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Color
+        notes:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Notes
+      type: object
+      required:
+      - name
+      title: TagSpec
     TaskResult:
       properties:
         gid:

--- a/src/core/asana_client.py
+++ b/src/core/asana_client.py
@@ -59,6 +59,11 @@ def get_client() -> any:
             path = f"/workspaces/{workspace_gid}/tags"
             return self._http.request_paginated("GET", path)
 
+        def create(self, payload: dict) -> dict:
+            # POST /tags
+            body = _wrap_data(payload)
+            return with_backoff(self._http.request, "POST", "/tags", json=body)
+
     class ProjectsProxy:
         def __init__(self, http_client: HttpClient) -> None:
             self._http = http_client
@@ -110,6 +115,12 @@ def get_client() -> any:
         def create_subtask(self, parent_task_gid: str, payload: dict) -> dict:
             body = _wrap_data(payload)
             path = f"/tasks/{parent_task_gid}/subtasks"
+            return with_backoff(self._http.request, "POST", path, json=body)
+
+        def add_tag(self, task_gid: str, tag_gid: str) -> dict:
+            # POST /tasks/{task_gid}/addTag
+            body = _wrap_data({"tag": tag_gid})
+            path = f"/tasks/{task_gid}/addTag"
             return with_backoff(self._http.request, "POST", path, json=body)
 
     class CustomFieldSettingsProxy:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -7,6 +7,12 @@ class SectionSpec(BaseModel):
     name: str | None = None
 
 
+class TagSpec(BaseModel):
+    name: str
+    color: str | None = None
+    notes: str | None = None
+
+
 class TaskSpec(BaseModel):
     name: str | None = None
     notes: str | None = None
@@ -70,6 +76,10 @@ class SectionResult(AsanaObject):
 
 
 class TaskResult(AsanaObject):
+    pass
+
+
+class TagResult(AsanaObject):
     pass
 
 

--- a/src/core/wrapper.py
+++ b/src/core/wrapper.py
@@ -9,6 +9,8 @@ from src.core.models import (
     ProjectResult,
     ProjectSpec,
     SectionResult,
+    TagResult,
+    TagSpec,
     TaskResult,
     TaskSpec,
 )
@@ -291,4 +293,27 @@ def create_tasks_in_project(project_gid: str, tasks_spec: list[TaskSpec]) -> lis
                 custom_field_option_map,
             )
     return created
+
+
+def create_tag(spec: TagSpec) -> TagResult:
+    """Create a tag in the configured workspace."""
+    client = get_client()
+    settings = get_settings()
+    payload: dict[str, Any] = {"name": spec.name, "workspace": settings.workspace_gid}
+    if spec.color:
+        payload["color"] = spec.color
+    if spec.notes:
+        payload["notes"] = spec.notes
+    tag = with_backoff(client.tags.create, payload)
+    return TagResult.model_validate(tag)
+
+
+def add_tags_to_task(task_gid: str, tag_gids: list[str]) -> list[TagResult]:
+    """Attach existing tags to a task."""
+    client = get_client()
+    results: list[TagResult] = []
+    for tag_gid in tag_gids:
+        tag = with_backoff(client.tasks.add_tag, task_gid, tag_gid)
+        results.append(TagResult.model_validate(tag))
+    return results
 

--- a/src/web/endpoints.py
+++ b/src/web/endpoints.py
@@ -4,12 +4,19 @@ from typing import Optional
 
 from fastapi import APIRouter, Body
 
-from src.core.wrapper import create_project_from_json, create_tasks_in_project
+from src.core.wrapper import (
+    add_tags_to_task,
+    create_project_from_json,
+    create_tag as create_tag_in_asana,
+    create_tasks_in_project,
+)
 from src.core.asana_mapping_generator import generate_asana_mapping
 from src.core.models import (
     MappingResult,
     ProjectResult,
     ProjectSpec,
+    TagResult,
+    TagSpec,
     TaskResult,
     TaskSpec,
 )
@@ -78,6 +85,18 @@ def create_tasks(
 
     created = create_tasks_in_project(project_gid, tasks)
     return created
+
+
+@router.post("/tag")
+def create_tag(spec: TagSpec = Body(...)) -> TagResult:
+    """Create a tag in the workspace."""
+    return create_tag_in_asana(spec)
+
+
+@router.post("/task/{task_gid}/tags")
+def add_tags(task_gid: str, tag_gids: list[str] = Body(...)) -> list[TagResult]:
+    """Attach existing tags to a task."""
+    return add_tags_to_task(task_gid, tag_gids)
 
 
 @router.post("/mapping")


### PR DESCRIPTION
## Summary
- allow creating tags through the wrapper and API
- support attaching tags to existing tasks
- document tag support and expose endpoints in OpenAPI spec

## Testing
- `poetry install --no-root` *(fails: Could not connect to pypi.org)*
- `python -m py_compile src/core/asana_client.py src/core/models.py src/core/wrapper.py src/web/endpoints.py`


------
https://chatgpt.com/codex/tasks/task_e_68acf92aab708321a4962611e9bd3416